### PR TITLE
Jacoco for Test Coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,13 @@ jobs:
       run: ./gradlew --build-cache checkstyleMain checkstyleTest --info
 
     - name: Test
-      run: ./gradlew --build-cache test --info
+      run: ./gradlew --build-cache test jacocoTestReport --info
+
+    - name: Codacy Coverage Reporter
+      uses: codacy/codacy-coverage-reporter-action@v1
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: build/reports/jacoco/test/jacocoTestReport.xml
 
     - name: Build
       run: ./gradlew --build-cache build --info

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     java
     id("io.freefair.lombok") version Versions.lombokPlugin
     checkstyle
+    jacoco
 }
 
 group = "dev.shopstack.security"
@@ -26,6 +27,14 @@ dependencies {
     testImplementation(Dependencies.assertjCore)
 }
 
+checkstyle {
+    toolVersion = Versions.checkstyle
+}
+
+jacoco {
+    toolVersion = Versions.jacoco
+}
+
 tasks {
     test {
         useJUnitPlatform {
@@ -34,7 +43,9 @@ tasks {
         failFast = true
     }
 
-    checkstyle {
-        toolVersion = Versions.checkstyle
+    jacocoTestReport {
+        reports {
+            xml.required.set(true)
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,6 +4,7 @@
 object Versions {
     const val lombokPlugin = "6.0.0-m2"
     const val checkstyle   = "8.44"
+    const val jacoco       = "0.8.7"
 
     // Testing
     const val junitJupiter = "5.8.0-M1"

--- a/src/main/java/dev/shopstack/security/hmac/HmacGenerator.java
+++ b/src/main/java/dev/shopstack/security/hmac/HmacGenerator.java
@@ -1,7 +1,6 @@
 package dev.shopstack.security.hmac;
 
 import dev.shopstack.security.hmac.exception.HmacGenerationFailureException;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,7 +17,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Verifies a SHA-256 cryptographic HMAC (hash-based message authentication code).
  */
 @Slf4j
-@Getter
 @RequiredArgsConstructor
 public final class HmacGenerator implements Function<String, String> {
 
@@ -43,8 +41,8 @@ public final class HmacGenerator implements Function<String, String> {
             return Base64.getEncoder().encodeToString(macData);
 
         } catch (NoSuchAlgorithmException | InvalidKeyException e) {
-            log.error("Unable to compute a message authentication code.", e);
-            throw new HmacGenerationFailureException("Unable to compute a message authentication code.", e);
+            log.error("Unable to compute an authentication code.", e);
+            throw new HmacGenerationFailureException("Unable to compute an authentication code.", e);
         }
     }
 

--- a/src/main/java/dev/shopstack/security/hmac/HmacVerifier.java
+++ b/src/main/java/dev/shopstack/security/hmac/HmacVerifier.java
@@ -1,6 +1,5 @@
 package dev.shopstack.security.hmac;
 
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.security.MessageDigest;
@@ -12,14 +11,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Provides methods to generate and verify HMACs (hash-based message authentication codes).
  */
 @Slf4j
-@Getter
 public final class HmacVerifier implements BiFunction<String, String, Boolean> {
 
-    private final String secret;
     private final HmacGenerator generator;
 
     public HmacVerifier(final String secret) {
-        this.secret = secret;
         this.generator = new HmacGenerator(secret);
     }
 

--- a/src/test/java/dev/shopstack/security/HmacGeneratorTest.java
+++ b/src/test/java/dev/shopstack/security/HmacGeneratorTest.java
@@ -1,9 +1,11 @@
 package dev.shopstack.security;
 
 import dev.shopstack.security.hmac.HmacGenerator;
+import dev.shopstack.security.hmac.exception.HmacGenerationFailureException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;

--- a/src/test/java/dev/shopstack/security/HmacGeneratorTest.java
+++ b/src/test/java/dev/shopstack/security/HmacGeneratorTest.java
@@ -1,11 +1,9 @@
 package dev.shopstack.security;
 
 import dev.shopstack.security.hmac.HmacGenerator;
-import dev.shopstack.security.hmac.exception.HmacGenerationFailureException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;


### PR DESCRIPTION
- Add Jacoco Gradle plugin.
- Upload Jacoco coverage reports to Codacy in build pipeline.