### PR TITLE
Maven Publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,9 +14,10 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 11
+        distribution: adopt
       
     - name: Gradle Cache
       uses: actions/cache@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish to Maven Central
 
-on: push
+on:
+  release:
+    types: [ published ]
 
 jobs:
 
@@ -29,7 +31,7 @@ jobs:
               ${{ runner.os }}-gradle-
 
         - name: Publish Package
-          run: ./gradlew publishToMavenLocal --info
+          run: ./gradlew publish --info
           env:
             ORG_GRADLE_PROJECT_sonatypeOSSUsername: "${{ secrets.SONATYPE_USERNAME }}"
             ORG_GRADLE_PROJECT_sonatypeOSSPassword: "${{ secrets.SONATYPE_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish to Maven Central
 
-on:
-  release:
-    types: [ published ]
+on: push
 
 jobs:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to Maven Central
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+
+    publish:
+      name: Publish to Maven Central
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: Setup Java
+          uses: actions/setup-java@v2
+          with:
+            java-version: 11
+            distribution: adopt
+
+        - name: Gradle Cache
+          uses: actions/cache@v2
+          with:
+            path: |
+              ~/.gradle/caches
+              ~/.gradle/wrapper
+            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+            restore-keys: |
+              ${{ runner.os }}-gradle-
+
+        - name: Publish Package
+          run: ./gradlew publishToMavenLocal --info
+          env:
+            ORG_GRADLE_PROJECT_sonatypeOSSUsername=: "${{ secrets.SONATYPE_OSSRH_USERNAME }}"
+            ORG_GRADLE_PROJECT_sonatypeOSSPassword: "${{ secrets.SONATYPE_OSSRH_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,6 @@
 name: Publish to Maven Central
 
-on:
-  release:
-    types: [ published ]
+on: push
 
 jobs:
 
@@ -30,8 +28,17 @@ jobs:
             restore-keys: |
               ${{ runner.os }}-gradle-
 
+        - name: Import GPG Key
+          id: import_gpg
+          uses: crazy-max/ghaction-import-gpg@v3
+          with:
+            gpg-private-key: "${{ secrets.GPG_PRIVATE_KEY }}"
+
+        - name: Generate Legacy Format of GPG Secret Keyring
+          run: gpg --keyring secring.gpg --export-secret-keys > /root/.gnupg/secring.gpg
+
         - name: Publish Package
-          run: ./gradlew publishToMavenLocal --info
+          run: ./gradlew publish --info -Psigning.secretKeyRingFile=/root/.gnupg/secring.gpg
           env:
-            ORG_GRADLE_PROJECT_sonatypeOSSUsername=: "${{ secrets.SONATYPE_OSSRH_USERNAME }}"
-            ORG_GRADLE_PROJECT_sonatypeOSSPassword: "${{ secrets.SONATYPE_OSSRH_TOKEN }}"
+            ORG_GRADLE_PROJECT_sonatypeOSSUsername: "${{ secrets.SONATYPE_USERNAME }}"
+            ORG_GRADLE_PROJECT_sonatypeOSSPassword: "${{ secrets.SONATYPE_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,16 +28,10 @@ jobs:
             restore-keys: |
               ${{ runner.os }}-gradle-
 
-        - name: Import GPG Key
-          uses: crazy-max/ghaction-import-gpg@v3
-          with:
-            gpg-private-key: "${{ secrets.GPG_PRIVATE_KEY }}"
-
-        - name: Generate Legacy Format of GPG Secret Keyring
-          run: gpg --keyring secring.gpg --export-secret-keys > /home/runner/.gnupg/secring.gpg
-
         - name: Publish Package
-          run: ./gradlew publishToMavenLocal --info -Psigning.secretKeyRingFile=/home/runner/.gnupg/secring.gpg
+          run: ./gradlew publishToMavenLocal --info
           env:
             ORG_GRADLE_PROJECT_sonatypeOSSUsername: "${{ secrets.SONATYPE_USERNAME }}"
             ORG_GRADLE_PROJECT_sonatypeOSSPassword: "${{ secrets.SONATYPE_TOKEN }}"
+            ORG_GRADLE_PROJECT_signingKey: "${{ secrets.GPG_SIGNING_KEY }}"
+            ORG_GRADLE_PROJECT_signingPassword: "${{ secrets.GPG_PASSPHRASE }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,10 +35,10 @@ jobs:
             gpg-private-key: "${{ secrets.GPG_PRIVATE_KEY }}"
 
         - name: Generate Legacy Format of GPG Secret Keyring
-          run: gpg --keyring secring.gpg --export-secret-keys > /root/.gnupg/secring.gpg
+          run: gpg --keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg
 
         - name: Publish Package
-          run: ./gradlew publish --info -Psigning.secretKeyRingFile=/root/.gnupg/secring.gpg
+          run: ./gradlew publishToMavenLocal --info -Psigning.secretKeyRingFile=~/.gnupg/secring.gpg
           env:
             ORG_GRADLE_PROJECT_sonatypeOSSUsername: "${{ secrets.SONATYPE_USERNAME }}"
             ORG_GRADLE_PROJECT_sonatypeOSSPassword: "${{ secrets.SONATYPE_TOKEN }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish to Maven Central
 
-on: push
+on:
+  release:
+    types: [ published ]
 
 jobs:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,16 +29,15 @@ jobs:
               ${{ runner.os }}-gradle-
 
         - name: Import GPG Key
-          id: import_gpg
           uses: crazy-max/ghaction-import-gpg@v3
           with:
             gpg-private-key: "${{ secrets.GPG_PRIVATE_KEY }}"
 
         - name: Generate Legacy Format of GPG Secret Keyring
-          run: gpg --keyring secring.gpg --export-secret-keys > ~/.gnupg/secring.gpg
+          run: gpg --keyring secring.gpg --export-secret-keys > /home/runner/.gnupg/secring.gpg
 
         - name: Publish Package
-          run: ./gradlew publishToMavenLocal --info -Psigning.secretKeyRingFile=~/.gnupg/secring.gpg
+          run: ./gradlew publishToMavenLocal --info -Psigning.secretKeyRingFile=/home/runner/.gnupg/secring.gpg
           env:
             ORG_GRADLE_PROJECT_sonatypeOSSUsername: "${{ secrets.SONATYPE_USERNAME }}"
             ORG_GRADLE_PROJECT_sonatypeOSSPassword: "${{ secrets.SONATYPE_TOKEN }}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,8 @@ plugins {
     id("io.freefair.lombok") version Versions.lombokPlugin
     checkstyle
     jacoco
+    `maven-publish`
 }
-
-group = "dev.shopstack.security"
-version = "0.1.0-SNAPSHOT"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
@@ -45,13 +43,63 @@ tasks {
         failFast = true
     }
 
-    jar {
-        from(sourceSets.main.get().allSource)
-    }
-
     jacocoTestReport {
         reports {
             xml.required.set(true)
+        }
+    }
+
+    val sourcesJar by creating(Jar::class) {
+        archiveClassifier.set("sources")
+        from(sourceSets.main.get().allSource)
+    }
+
+    val javadocJar by creating(Jar::class) {
+        dependsOn.add(javadoc)
+        archiveClassifier.set("javadoc")
+        from(javadoc)
+    }
+
+    artifacts {
+        archives(sourcesJar)
+        archives(javadocJar)
+        archives(jar)
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            groupId = "dev.shopstack.security"
+            artifactId = "shopstack-security-hmac"
+            version = "1.0.0"
+
+            from(components["java"])
+
+            pom {
+                name.set("Shopstack Security HMAC")
+                description.set("A library to authenticate Shopify requests using the provided HMAC.")
+                url.set("https://shopstack.dev")
+                scm {
+                    connection.set("scm:git:git://github.com/shopstack-projects/shopstack-security-hmac.git")
+                    developerConnection.set("scm:git:ssh://github.com/shopstack-projects/shopstack-security-hmac.git")
+                    url.set("https://github.com/shopstack-projects/shopstack-security-hmac/")
+                }
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://opensource.org/licenses/MIT")
+                        distribution.set("repo")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("alanguerin")
+                        name.set("Alan Guerin")
+                        email.set("alan@alanguerin.com")
+                    }
+                }
+            }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     signing
 }
 
-version = "1.0.0"
+version = "1.0.0.RELEASE"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
@@ -111,7 +111,7 @@ tasks {
         val signingPassword: String? by project
 
         if (signingKey != null) {
-            useInMemoryPgpKeys(base64Decode(signingKey), signingPassword)
+            useInMemoryPgpKeys(base64Decode(signingKey), base64Decode(signingPassword))
             sign(publishing.publications["mavenJava"])
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,10 @@ plugins {
     checkstyle
     jacoco
     `maven-publish`
+    signing
 }
+
+version = "1.0.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
@@ -38,31 +41,12 @@ jacoco {
     toolVersion = Versions.jacoco
 }
 
-
-
-tasks {
-    test {
-        useJUnitPlatform {
-            maxParallelForks = Runtime.getRuntime().availableProcessors()
-        }
-        failFast = true
-    }
-
-    jacocoTestReport {
-        reports {
-            xml.required.set(true)
-        }
-    }
-}
-
 publishing {
-    val artifactVersion = "1.0.0"
 
     publications {
         create<MavenPublication>("mavenJava") {
             groupId = "dev.shopstack.security"
             artifactId = "shopstack-security-hmac"
-            version = artifactVersion
 
             from(components["java"])
 
@@ -99,7 +83,28 @@ publishing {
             val sonatypeBaseUri = "https://s01.oss.sonatype.org/content/repositories"
             val releasesRepo = uri("$sonatypeBaseUri/releases")
             val snapshotsRepo = uri("$sonatypeBaseUri/snapshots")
-            url = snapshotsRepo // FIXME if (artifactVersion.endsWith("RELEASE")) releasesRepo else snapshotsRepo
+            url = if (version.toString().endsWith("RELEASE")) releasesRepo else snapshotsRepo
         }
     }
+}
+
+tasks {
+    test {
+        useJUnitPlatform {
+            maxParallelForks = Runtime.getRuntime().availableProcessors()
+        }
+        failFast = true
+    }
+
+    jacocoTestReport {
+        reports {
+            xml.required.set(true)
+        }
+    }
+
+    signing {
+        isRequired = version.toString().endsWith("RELEASE")
+        sign(publishing.publications["mavenJava"])
+    }
+
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,7 @@ tasks {
     }
 
     signing {
-        isRequired = version.toString().endsWith("RELEASE")
+        isRequired = true // FIXME version.toString().endsWith("RELEASE")
         sign(publishing.publications["mavenJava"])
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     signing
 }
 
-version = "1.0.0.RELEASE"
+version = "1.0.0"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,9 @@ plugins {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+
+    withSourcesJar()
+    withJavadocJar()
 }
 
 repositories {
@@ -35,6 +38,8 @@ jacoco {
     toolVersion = Versions.jacoco
 }
 
+
+
 tasks {
     test {
         useJUnitPlatform {
@@ -48,42 +53,27 @@ tasks {
             xml.required.set(true)
         }
     }
-
-    val sourcesJar by creating(Jar::class) {
-        archiveClassifier.set("sources")
-        from(sourceSets.main.get().allSource)
-    }
-
-    val javadocJar by creating(Jar::class) {
-        dependsOn.add(javadoc)
-        archiveClassifier.set("javadoc")
-        from(javadoc)
-    }
-
-    artifacts {
-        archives(sourcesJar)
-        archives(javadocJar)
-        archives(jar)
-    }
 }
 
 publishing {
+    val artifactVersion = "1.0.0"
+
     publications {
         create<MavenPublication>("mavenJava") {
             groupId = "dev.shopstack.security"
             artifactId = "shopstack-security-hmac"
-            version = "1.0.0"
+            version = artifactVersion
 
             from(components["java"])
 
             pom {
                 name.set("Shopstack Security HMAC")
-                description.set("A library to authenticate Shopify requests using the provided HMAC.")
+                description.set("Authenticate Shopify requests using the provided HMAC.")
                 url.set("https://shopstack.dev")
                 scm {
                     connection.set("scm:git:git://github.com/shopstack-projects/shopstack-security-hmac.git")
                     developerConnection.set("scm:git:ssh://github.com/shopstack-projects/shopstack-security-hmac.git")
-                    url.set("https://github.com/shopstack-projects/shopstack-security-hmac/")
+                    url.set("https://github.com/shopstack-projects/shopstack-security-hmac/tree/main")
                 }
                 licenses {
                     license {
@@ -96,10 +86,20 @@ publishing {
                     developer {
                         id.set("alanguerin")
                         name.set("Alan Guerin")
-                        email.set("alan@alanguerin.com")
+                        email.set("hello@alanguerin.com")
                     }
                 }
             }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "SonatypeOSS"
+            val sonatypeBaseUri = "https://s01.oss.sonatype.org/content/repositories"
+            val releasesRepo = uri("$sonatypeBaseUri/releases")
+            val snapshotsRepo = uri("$sonatypeBaseUri/snapshots")
+            url = snapshotsRepo // FIXME if (artifactVersion.endsWith("RELEASE")) releasesRepo else snapshotsRepo
         }
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,7 +2,7 @@
  * Version reference for project dependencies.
  */
 object Versions {
-    const val lombokPlugin = "6.0.0-m2"
+    const val lombokPlugin = "6.1.0-m1"
     const val checkstyle   = "8.44"
     const val jacoco       = "0.8.7"
 


### PR DESCRIPTION
- Add a GitHub Actions workflow to publish the artifact  to the Sonatype OSS Repository Hosting service.
- Artifacts are signed with a Gnu Privacy Guard (GPG) key to allow authenticity to be verified.