### PR TITLE
Configurable Encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ String hmac = queryParameters.get("hmac");
     
 String message = queryParameters.keySet().stream()
     .filter(key -> !key.equalsIgnoreCase("hmac"))
-    .map(key -> key + "=" + queryParams.get(key))
+    .map(key -> key + "=" + queryParameters.get(key))
     .sorted() // Lexicographic order is required.
     .collect(joining("&"));
 
@@ -101,7 +101,7 @@ String hmac = queryParameters.get("hmac");
 
 String message = queryParameters.keySet().stream()
     .filter(key -> !key.equalsIgnoreCase("hmac"))
-    .map(key -> key + "=" + queryParams.get(key))
+    .map(key -> key + "=" + queryParameters.get(key))
     .sorted() // Lexicographic order is required.
     .collect(joining("&"));
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,8 @@ repositories {
 }
 
 dependencies {
+    implementation(Dependencies.apacheCommonsCodec)
+
     implementation(Dependencies.slf4jApi)
     testImplementation(Dependencies.slf4jSimpleLogger)
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,23 +2,31 @@
  * Version reference for project dependencies.
  */
 object Versions {
-    const val lombokPlugin = "6.1.0-m1"
-    const val checkstyle   = "8.44"
+    const val lombokPlugin = "6.1.0"
+    const val checkstyle   = "8.45.1"
     const val jacoco       = "0.8.7"
 
-    // Testing
-    const val junitJupiter = "5.8.0-M1"
-    const val assertj      = "3.20.2"
-    const val mockito      = "3.11.2"
+    const val commonsCodec = "1.15"
 
     // Logging
-    const val slf4j        = "2.0.0-alpha2"
+    const val slf4j        = "2.0.0-alpha5"
+
+    // Testing
+    const val junitJupiter = "5.8.0-RC1"
+    const val assertj      = "3.20.2"
+    const val mockito      = "3.12.4"
 }
 
 /**
  * Project dependency reference.
  */
 object Dependencies {
+    const val apacheCommonsCodec  = "commons-codec:commons-codec:${Versions.commonsCodec}"
+
+    // Logging
+    const val slf4jApi            = "org.slf4j:slf4j-api:${Versions.slf4j}"
+    const val slf4jSimpleLogger   = "org.slf4j:slf4j-simple:${Versions.slf4j}"
+
     // Testing
     const val junitJupiterApi     = "org.junit.jupiter:junit-jupiter-api:${Versions.junitJupiter}"
     const val junitJupiterEngine  = "org.junit.jupiter:junit-jupiter-engine:${Versions.junitJupiter}"
@@ -26,8 +34,4 @@ object Dependencies {
     const val assertjCore         = "org.assertj:assertj-core:${Versions.assertj}"
     const val mockitoInline       = "org.mockito:mockito-inline:${Versions.mockito}"
     const val mockitoJunitJupiter = "org.mockito:mockito-junit-jupiter:${Versions.mockito}"
-
-    // Logging
-    const val slf4jApi            = "org.slf4j:slf4j-api:${Versions.slf4j}"
-    const val slf4jSimpleLogger   = "org.slf4j:slf4j-simple:${Versions.slf4j}"
 }

--- a/src/main/java/dev/shopstack/security/hmac/Encoding.java
+++ b/src/main/java/dev/shopstack/security/hmac/Encoding.java
@@ -1,0 +1,11 @@
+package dev.shopstack.security.hmac;
+
+/**
+ * Data encodings used when generating HMACs.
+ */
+public enum Encoding {
+
+    BASE16,
+    BASE64
+
+}

--- a/src/main/java/dev/shopstack/security/hmac/HmacGenerator.java
+++ b/src/main/java/dev/shopstack/security/hmac/HmacGenerator.java
@@ -15,6 +15,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.function.Function;
 
 import static dev.shopstack.security.hmac.Encoding.BASE16;
+import static dev.shopstack.security.hmac.Encoding.BASE64;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -29,8 +30,7 @@ public final class HmacGenerator implements Function<String, String> {
     private final BinaryEncoder encoder;
 
     public HmacGenerator(final String secret) {
-        this.mac = initMac(secret);
-        this.encoder = new Base64();
+        this(secret, BASE64);
     }
 
     public HmacGenerator(final String secret, final Encoding encoding) {
@@ -72,7 +72,7 @@ public final class HmacGenerator implements Function<String, String> {
     }
 
     /**
-     * Create a {@link BinaryEncoder} object using the provided {@link Encoding}.
+     * Create a suitable {@link BinaryEncoder} instance for the provided {@link Encoding}.
      */
     private BinaryEncoder buildEncoder(Encoding encoding) {
         if (encoding == BASE16) {

--- a/src/main/java/dev/shopstack/security/hmac/HmacVerifier.java
+++ b/src/main/java/dev/shopstack/security/hmac/HmacVerifier.java
@@ -5,10 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import java.security.MessageDigest;
 import java.util.function.BiFunction;
 
+import static dev.shopstack.security.hmac.Encoding.BASE64;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
- * Provides methods to generate and verify HMACs (hash-based message authentication codes).
+ * Verifies a SHA-256 based HMAC (hash-based message authentication code).
  */
 @Slf4j
 public final class HmacVerifier implements BiFunction<String, String, Boolean> {
@@ -16,7 +17,11 @@ public final class HmacVerifier implements BiFunction<String, String, Boolean> {
     private final HmacGenerator generator;
 
     public HmacVerifier(final String secret) {
-        this.generator = new HmacGenerator(secret);
+        this.generator = new HmacGenerator(secret, BASE64);
+    }
+
+    public HmacVerifier(final String secret, final Encoding encoding)  {
+        this.generator = new HmacGenerator(secret, encoding);
     }
 
     /**

--- a/src/main/java/dev/shopstack/security/hmac/exception/HmacEncodingException.java
+++ b/src/main/java/dev/shopstack/security/hmac/exception/HmacEncodingException.java
@@ -1,0 +1,17 @@
+package dev.shopstack.security.hmac.exception;
+
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PRIVATE;
+
+/**
+ * Exception thrown when a problem occurs when encoding a HMAC.
+ */
+@NoArgsConstructor(access = PRIVATE)
+public final class HmacEncodingException extends RuntimeException {
+
+    public HmacEncodingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/test/java/dev/shopstack/security/hmac/HmacGeneratorTest.java
+++ b/src/test/java/dev/shopstack/security/hmac/HmacGeneratorTest.java
@@ -1,8 +1,10 @@
 package dev.shopstack.security.hmac;
 
+import dev.shopstack.security.hmac.exception.HmacEncodingException;
 import dev.shopstack.security.hmac.exception.HmacGeneratorInitializationException;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.codec.binary.Base16;
+import org.apache.commons.codec.BinaryEncoder;
+import org.apache.commons.codec.EncoderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,12 +18,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import java.lang.reflect.Field;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.stream.IntStream;
 
-import static dev.shopstack.security.hmac.Encoding.BASE16;
-import static dev.shopstack.security.hmac.Encoding.BASE64;
 import static dev.shopstack.security.test.util.RandomStringUtils.randomAlphaNumeric;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,6 +31,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 
 /**
  * Test suite for {@link HmacGenerator}.
@@ -56,7 +58,7 @@ public final class HmacGeneratorTest {
         }
 
         @Test
-        void constructor_whenMacInitializedWithBadKeySpec_thenExpectException() throws InvalidKeyException {
+        void constructor_whenMacInitializedWithBadKeySpec_thenExpectException() throws Exception {
             try (MockedStatic<Mac> mac = mockStatic(Mac.class)) {
                 Mac macInstance = mock(Mac.class);
 
@@ -83,7 +85,7 @@ public final class HmacGeneratorTest {
 
         @BeforeEach
         void beforeEach() {
-            generator = new HmacGenerator(generateSecret());
+            generator = spy(new HmacGenerator(generateSecret()));
         }
 
         @Test
@@ -132,6 +134,24 @@ public final class HmacGeneratorTest {
             String hmac = generator.apply(content);
             log.info("Generated HMAC: {}", hmac);
             assertThat(hmac).isNotBlank();
+        }
+
+        @ParameterizedTest
+        @EnumSource(Encoding.class)
+        void constructor_whenEncodingFails_thenExpectException(Encoding encoding) throws Exception {
+            generator = new HmacGenerator(generateSecret(), encoding);
+
+            // Overwrite the generator's internal encoder.
+            Field encoderField = generator.getClass().getDeclaredField("encoder");
+            encoderField.setAccessible(true);
+
+            BinaryEncoder encoder = mock(BinaryEncoder.class);
+            encoderField.set(generator, encoder);
+
+            doThrow(new EncoderException()).when(encoder).encode(any());
+
+            assertThatThrownBy(() -> generator.apply(generateContent()))
+                .isInstanceOf(HmacEncodingException.class);
         }
 
     }

--- a/src/test/java/dev/shopstack/security/hmac/HmacGeneratorTest.java
+++ b/src/test/java/dev/shopstack/security/hmac/HmacGeneratorTest.java
@@ -138,7 +138,7 @@ public final class HmacGeneratorTest {
 
         @ParameterizedTest
         @EnumSource(Encoding.class)
-        void constructor_whenEncodingFails_thenExpectException(Encoding encoding) throws Exception {
+        void apply_whenEncodingFails_thenExpectException(Encoding encoding) throws Exception {
             generator = new HmacGenerator(generateSecret(), encoding);
 
             // Overwrite the generator's internal encoder.

--- a/src/test/java/dev/shopstack/security/hmac/HmacGeneratorTest.java
+++ b/src/test/java/dev/shopstack/security/hmac/HmacGeneratorTest.java
@@ -2,12 +2,14 @@ package dev.shopstack.security.hmac;
 
 import dev.shopstack.security.hmac.exception.HmacGeneratorInitializationException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base16;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -18,6 +20,8 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.stream.IntStream;
 
+import static dev.shopstack.security.hmac.Encoding.BASE16;
+import static dev.shopstack.security.hmac.Encoding.BASE64;
 import static dev.shopstack.security.test.util.RandomStringUtils.randomAlphaNumeric;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -117,6 +121,17 @@ public final class HmacGeneratorTest {
             });
 
             assertThat(true).isTrue(); // Passes PMD checks.
+        }
+
+        @ParameterizedTest
+        @EnumSource(Encoding.class)
+        void apply_givenDifferentEncodings_thenExpectSuccess(Encoding encoding) {
+            generator = new HmacGenerator(generateSecret(), encoding);
+            String content = generateContent();
+
+            String hmac = generator.apply(content);
+            log.info("Generated HMAC: {}", hmac);
+            assertThat(hmac).isNotBlank();
         }
 
     }

--- a/src/test/java/dev/shopstack/security/hmac/HmacVerifierTest.java
+++ b/src/test/java/dev/shopstack/security/hmac/HmacVerifierTest.java
@@ -2,12 +2,15 @@ package dev.shopstack.security.hmac;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 
 import java.util.stream.IntStream;
 
+import static dev.shopstack.security.hmac.Encoding.BASE16;
+import static dev.shopstack.security.hmac.Encoding.BASE64;
 import static dev.shopstack.security.test.util.RandomStringUtils.randomAlphaNumeric;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -18,76 +21,149 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Slf4j
 public final class HmacVerifierTest {
 
-    private HmacVerifier verifier;
-    private HmacGenerator generator;
+    /**
+     * Test cases for {@link HmacVerifier#apply(String, String)} when using {@link Encoding#BASE64}.
+     */
+    @Nested
+    class ApplyUsingBase64Encoding {
 
-    @BeforeEach
-    void beforeEach() {
-        String secret = generateSecret();
+        private HmacVerifier verifier;
+        private HmacGenerator generator;
 
-        verifier = new HmacVerifier(secret);
-        generator = new HmacGenerator(secret);
-    }
+        @BeforeEach
+        void beforeEach() {
+            String secret = generateSecret();
 
-    @Test
-    void apply_whenContentIsValid_thenExpectSuccess() {
-        String content = generateContent();
+            verifier = new HmacVerifier(secret);
+            generator = new HmacGenerator(secret);
+        }
 
-        String hmac = generator.apply(content);
-        log.info("Generated HMAC: {}", hmac);
-        assertThat(hmac).isNotBlank();
-
-        boolean result = verifier.apply(hmac, content);
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    void apply_whenContentHasChanged_thenExpectFailure() {
-        String content = generateContent();
-
-        String hmac = generator.apply(content);
-        log.info("Generated HMAC: {}", hmac);
-        assertThat(hmac).isNotBlank();
-
-        String newContent = generateContent();
-        assertThat(content).isNotEqualTo(newContent);
-
-        boolean result = verifier.apply(hmac, newContent);
-        assertThat(result).isFalse();
-    }
-
-    @ParameterizedTest
-    @NullSource
-    void apply_whenHmacIsNull_thenExpectException(String hmac) {
-        String content = generateContent();
-
-        assertThatThrownBy(() -> verifier.apply(hmac, content))
-            .isInstanceOf(NullPointerException.class);
-    }
-
-    @ParameterizedTest
-    @NullSource
-    void apply_whenContentIsNull_thenExpectException(String content) {
-        String hmac = generator.apply(generateContent());
-
-        assertThatThrownBy(() -> verifier.apply(hmac, content))
-            .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    void apply_givenMultipleSequentialCalls_whenContentIsValid_thenExpectSuccess() {
-        IntStream.rangeClosed(1, 3).forEach(i -> {
+        @Test
+        void apply_whenContentIsValid_thenExpectSuccess() {
             String content = generateContent();
 
             String hmac = generator.apply(content);
-            log.info("Generated HMAC {}: {}", i, hmac);
+            log.info("Generated HMAC: {}", hmac);
             assertThat(hmac).isNotBlank();
 
             boolean result = verifier.apply(hmac, content);
             assertThat(result).isTrue();
-        });
+        }
 
-        assertThat(true).isTrue(); // Passes PMD checks.
+        @Test
+        void apply_whenContentHasChanged_thenExpectFailure() {
+            String content = generateContent();
+
+            String hmac = generator.apply(content);
+            log.info("Generated HMAC: {}", hmac);
+            assertThat(hmac).isNotBlank();
+
+            String newContent = generateContent();
+            assertThat(content).isNotEqualTo(newContent);
+
+            boolean result = verifier.apply(hmac, newContent);
+            assertThat(result).isFalse();
+        }
+
+        @ParameterizedTest
+        @NullSource
+        void apply_whenHmacIsNull_thenExpectException(String hmac) {
+            String content = generateContent();
+
+            assertThatThrownBy(() -> verifier.apply(hmac, content))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @ParameterizedTest
+        @NullSource
+        void apply_whenContentIsNull_thenExpectException(String content) {
+            String hmac = generator.apply(generateContent());
+
+            assertThatThrownBy(() -> verifier.apply(hmac, content))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        void apply_givenMultipleSequentialCalls_whenContentIsValid_thenExpectSuccess() {
+            IntStream.rangeClosed(1, 3).forEach(i -> {
+                String content = generateContent();
+
+                String hmac = generator.apply(content);
+                log.info("Generated HMAC {}: {}", i, hmac);
+                assertThat(hmac).isNotBlank();
+
+                boolean result = verifier.apply(hmac, content);
+                assertThat(result).isTrue();
+            });
+
+            assertThat(true).isTrue(); // Passes PMD checks.
+        }
+
+        @Test
+        void apply_whenHmacIsBase16Encoded_thenExpectFailure() {
+            String secret = generateSecret();
+
+            HmacGenerator generator = new HmacGenerator(secret, BASE16);
+            HmacVerifier verifier = new HmacVerifier(secret, BASE64);
+
+            String content = generateContent();
+
+            String hmac = generator.apply(content); // Generate Base16
+            log.info("Generated HMAC: {}", hmac);
+            assertThat(hmac).isNotBlank();
+
+            boolean result = verifier.apply(hmac, content); // Verify Base64
+            assertThat(result).isFalse();
+        }
+
+    }
+
+    /**
+     * Test cases for {@link HmacVerifier#apply(String, String)} when using {@link Encoding#BASE16}.
+     */
+    @Nested
+    class ApplyUsingBase16Encoding {
+
+        private HmacVerifier verifier;
+        private HmacGenerator generator;
+
+        @BeforeEach
+        void beforeEach() {
+            String secret = generateSecret();
+
+            verifier = new HmacVerifier(secret, BASE16);
+            generator = new HmacGenerator(secret, BASE16);
+        }
+
+        @Test
+        void apply_whenContentIsValid_thenExpectSuccess() {
+            String content = generateContent();
+
+            String hmac = generator.apply(content);
+            log.info("Generated HMAC: {}", hmac);
+            assertThat(hmac).isNotBlank();
+
+            boolean result = verifier.apply(hmac, content);
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void apply_whenHmacIsBase64Encoded_thenExpectFailure() {
+            String secret = generateSecret();
+
+            HmacGenerator generator = new HmacGenerator(secret, BASE64);
+            HmacVerifier verifier = new HmacVerifier(secret, BASE16);
+
+            String content = generateContent();
+
+            String hmac = generator.apply(content); // Generate Base64
+            log.info("Generated HMAC: {}", hmac);
+            assertThat(hmac).isNotBlank();
+
+            boolean result = verifier.apply(hmac, content); // Verify Base16
+            assertThat(result).isFalse();
+        }
+
     }
 
     /* Fixtures */

--- a/src/test/java/dev/shopstack/security/hmac/HmacVerifierTest.java
+++ b/src/test/java/dev/shopstack/security/hmac/HmacVerifierTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public final class HmacVerifierTest {
 
     /**
-     * Test cases for {@link HmacVerifier#apply(String, String)} when using {@link Encoding#BASE64}.
+     * Test cases for {@link HmacVerifier#apply(String, String)}.
      */
     @Nested
     class Apply {


### PR DESCRIPTION
- Add selectable data encoder to `HmacGenerator`.
- Update README to explain different encoding use cases in Shopify requests.
- Upgrade dependency versions.